### PR TITLE
Fix back button to always navigate to song list

### DIFF
--- a/src/widgets/song-view/ui/arrow-back/arrow-back.tsx
+++ b/src/widgets/song-view/ui/arrow-back/arrow-back.tsx
@@ -13,7 +13,7 @@ const ArrowBack = ({ className }: ArrowBackType) => {
   const navigation = useRouter();
 
   const handleGoBack = () => {
-    navigation.back();
+    navigation.push('/');
   };
 
   return (


### PR DESCRIPTION
router.back() fails when a song is opened via direct link because there
is no browser history entry for the song list. Replace with router.push('/')
so the back button reliably returns to the song list in all cases.
Scroll restoration still works because the clicked song ID is stored in
sessionStorage and read on mount regardless of navigation method.

https://claude.ai/code/session_01C7ZUM56wZ8F9uAM6wdXisp