### PR TITLE
fix: bypass Next.js fetch cache for Supabase song queries

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,16 @@
+const crypto = require('crypto');
+
+const buildId = crypto.randomBytes(8).toString('hex');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
 
   output: 'export',
+
+  env: {
+    NEXT_PUBLIC_BUILD_ID: buildId,
+  },
 };
 
 module.exports = nextConfig;

--- a/src/entities/song/api/supabase.ts
+++ b/src/entities/song/api/supabase.ts
@@ -18,7 +18,9 @@ export async function fetchSongs(): Promise<SongRow[]> {
     );
   }
 
-  const supabase = createClient(url, key);
+  const supabase = createClient(url, key, {
+    global: { fetch: (input, init) => fetch(input, { ...init, cache: 'no-store' }) },
+  });
 
   const { data, error } = await supabase
     .from('songs')
@@ -47,7 +49,9 @@ export async function fetchSongById(id: number): Promise<SongRow | null> {
     );
   }
 
-  const supabase = createClient(url, key);
+  const supabase = createClient(url, key, {
+    global: { fetch: (input, init) => fetch(input, { ...init, cache: 'no-store' }) },
+  });
 
   const { data, error } = await supabase
     .from('songs')

--- a/src/entities/song/model/use-song-list.ts
+++ b/src/entities/song/model/use-song-list.ts
@@ -4,12 +4,21 @@ import supabase from '@/shared/lib/supabase-browser';
 
 import type { SongEntry } from './types';
 
-const CACHE_KEY = 'songs_cache';
+const CACHE_PREFIX = 'songs_cache_';
+const CACHE_KEY = `${CACHE_PREFIX}${process.env.NEXT_PUBLIC_BUILD_ID ?? 'dev'}`;
+
+function purgeOldCaches() {
+  Object.keys(localStorage)
+    .filter((k) => k.startsWith(CACHE_PREFIX) && k !== CACHE_KEY)
+    .forEach((k) => localStorage.removeItem(k));
+}
 
 export function useSongList(): { songs: SongEntry[] } {
   const [songs, setSongs] = useState<SongEntry[]>([]);
 
   useEffect(() => {
+    purgeOldCaches();
+
     const cached = localStorage.getItem(CACHE_KEY);
     if (cached) {
       try {
@@ -30,10 +39,7 @@ export function useSongList(): { songs: SongEntry[] } {
           num: r.sort_order as number,
         }));
         setSongs(entries);
-        localStorage.setItem(
-          CACHE_KEY,
-          JSON.stringify({ songs: entries, updatedAt: Date.now() }),
-        );
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ songs: entries }));
       });
   }, []);
 


### PR DESCRIPTION
Next.js caches fetch() responses between builds. Edited songs were served
from the previous build's cache because the URL was unchanged. New songs
worked because they had no cache entry. Adding cache: 'no-store' forces
fresh DB reads on every build.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V9PZAEAp1pD5XPU9Jncg9R