### PR TITLE
fix: song record cache on build

### DIFF
--- a/src/entities/song/api/supabase.ts
+++ b/src/entities/song/api/supabase.ts
@@ -1,5 +1,3 @@
-import { createClient } from '@supabase/supabase-js';
-
 export interface SongRow {
   id: number;
   name: string;
@@ -8,58 +6,56 @@ export interface SongRow {
   sort_order: number;
 }
 
-export async function fetchSongs(): Promise<SongRow[]> {
+function getEnv() {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_PUBLISHABLE_DEFAULT_KEY;
-
   if (!url || !key) {
     throw new Error(
       'Missing SUPABASE_URL or SUPABASE_PUBLISHABLE_DEFAULT_KEY environment variables',
     );
   }
+  return { url, key };
+}
 
-  const supabase = createClient(url, key, {
-    global: { fetch: (input, init) => fetch(input, { ...init, cache: 'no-store' }) },
-  });
+const SELECT = 'id,name,key,lyrics,sort_order';
 
-  const { data, error } = await supabase
-    .from('songs')
-    .select('id, name, key, lyrics, sort_order')
-    .order('sort_order', { ascending: true })
-    .order('name', { ascending: true });
+export async function fetchSongs(): Promise<SongRow[]> {
+  const { url, key } = getEnv();
 
-  if (error) {
-    throw new Error(`Supabase fetch failed: ${error.message}`);
-  }
+  const res = await fetch(
+    `${url}/rest/v1/songs?select=${SELECT}&order=sort_order.asc,name.asc`,
+    {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      cache: 'no-store',
+    },
+  );
 
-  if (!data || data.length === 0) {
-    throw new Error('No songs found in Supabase');
-  }
+  if (!res.ok) throw new Error(`Supabase fetch failed: ${res.statusText}`);
 
-  return data as SongRow[];
+  const data: SongRow[] = await res.json();
+
+  if (!data || data.length === 0) throw new Error('No songs found in Supabase');
+
+  return data;
 }
 
 export async function fetchSongById(id: number): Promise<SongRow | null> {
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+  const { url, key } = getEnv();
 
-  if (!url || !key) {
-    throw new Error(
-      'Missing SUPABASE_URL or SUPABASE_PUBLISHABLE_DEFAULT_KEY environment variables',
-    );
-  }
+  const res = await fetch(
+    `${url}/rest/v1/songs?select=${SELECT}&id=eq.${id}`,
+    {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Accept: 'application/vnd.pgrst.object+json',
+      },
+      cache: 'no-store',
+    },
+  );
 
-  const supabase = createClient(url, key, {
-    global: { fetch: (input, init) => fetch(input, { ...init, cache: 'no-store' }) },
-  });
+  if (res.status === 406 || res.status === 404) return null;
+  if (!res.ok) return null;
 
-  const { data, error } = await supabase
-    .from('songs')
-    .select('id, name, key, lyrics, sort_order')
-    .eq('id', id)
-    .single();
-
-  if (error) return null;
-
-  return data as SongRow;
+  return res.json();
 }


### PR DESCRIPTION
## Summary

- **Root cause**: Next.js caches `fetch()` responses between builds. Edited songs hit the same URL as the previous build, so the cached (stale) HTML was served. New songs worked because they had no cache entry.
- Replaced Supabase client build-time queries with raw `fetch(..., { cache: 'no-store' })` calls so every build always hits the DB fresh.
- Added `NEXT_PUBLIC_BUILD_ID` (random hash generated per build) as the `localStorage` songs cache key — after a new deployment, the old key is missing so songs are refetched. Old stale keys are purged on first load.

## Test plan

- [ ] Edit a song in the DB, press Deploy — confirm the updated song appears after build
- [ ] Add a new song — confirm it appears after build (existing behaviour)
- [ ] Open the song list — confirm songs load correctly (no not-found pages)
- [ ] Check localStorage — old `songs_cache_*` keys are removed, new key matches current build

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9PZAEAp1pD5XPU9Jncg9R)_