### PR TITLE
fix: song record stale data on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "rm -rf .next/cache && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/entities/song/api/supabase.ts
+++ b/src/entities/song/api/supabase.ts
@@ -26,7 +26,7 @@ export async function fetchSongs(): Promise<SongRow[]> {
     `${url}/rest/v1/songs?select=${SELECT}&order=sort_order.asc,name.asc`,
     {
       headers: { apikey: key, Authorization: `Bearer ${key}` },
-      cache: 'no-store',
+      next: { revalidate: false },
     },
   );
 
@@ -50,7 +50,7 @@ export async function fetchSongById(id: number): Promise<SongRow | null> {
         Authorization: `Bearer ${key}`,
         Accept: 'application/vnd.pgrst.object+json',
       },
-      cache: 'no-store',
+      next: { revalidate: false },
     },
   );
 


### PR DESCRIPTION
## Summary

- **Root cause**: Next.js persists its fetch cache to disk (`.next/cache/fetch-cache`) between builds. Edited songs hit the same cached URL from the previous build — new songs worked because they had no cache entry yet.
- Replaced the Supabase client with raw `fetch` calls for build-time functions (`fetchSongs`, `fetchSongById`) for explicit control.
- Used `next: { revalidate: false }` (static, compatible with `output: 'export'`) instead of `cache: 'no-store'` which would break the static export build.
- Added `rm -rf .next/cache` to the `build` script so the fetch cache is cleared before every build — guaranteeing fresh data from Supabase each time.
- Added `NEXT_PUBLIC_BUILD_ID` (random hash per build) as the `localStorage` songs cache key so the client-side list refreshes automatically after a new deployment.

## Test plan

- [ ] Edit a song in the DB, press Deploy — confirm updated song appears after build
- [ ] Add a new song — confirm it appears after build
- [ ] Open the song list — songs load correctly, no not-found pages
- [ ] Check `localStorage` — old `songs_cache_*` keys removed, new key matches current build

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9PZAEAp1pD5XPU9Jncg9R)_