### PR TITLE
Add dark mode that follows browser/OS preference

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import '@/shared/styles/global.scss';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Montserrat } from 'next/font/google';
 
 const inter = Montserrat({ subsets: ['latin'] });
@@ -10,6 +10,13 @@ export const metadata: Metadata = {
     template: '%s | Worship',
   },
   description: 'Міні пісеник',
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#121212' },
+  ],
 };
 
 export default function RootLayout({

--- a/src/app/song/[id]/_song-not-found.module.scss
+++ b/src/app/song/[id]/_song-not-found.module.scss
@@ -7,7 +7,7 @@
 
 .message {
   font-size: 16px;
-  color: #555;
+  color: var(--text-secondary);
   line-height: 1.5;
   margin: 0;
 }

--- a/src/app/song/[id]/page.module.scss
+++ b/src/app/song/[id]/page.module.scss
@@ -11,7 +11,7 @@
   align-items: center;
   align-self: stretch;
 
-  color: color(grey, 100);
+  color: var(--on-accent);
   font-size: 36px;
   font-style: normal;
   font-weight: 500;
@@ -23,7 +23,7 @@
   &__wrapper {
     display: grid;
     justify-content: center;
-    background: color(white);
+    background: var(--bg-page);
     border-radius: 30px 30px 0px 0px;
     box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25) inset;
   }

--- a/src/entities/song/ui/song-block/song-block.module.scss
+++ b/src/entities/song/ui/song-block/song-block.module.scss
@@ -2,14 +2,14 @@
 
 .text {
   display: grid;
-  color: color(text);
+  color: var(--text-primary);
   font-size: 20px;
   font-style: normal;
   font-weight: 400;
   line-height: 27px;
   white-space: pre-wrap;
   &__chords {
-    color: color(chords);
+    color: var(--chords);
     font-weight: 700;
   }
 }

--- a/src/entities/song/ui/song-list-item/song-list-item.module.scss
+++ b/src/entities/song/ui/song-list-item/song-list-item.module.scss
@@ -7,9 +7,9 @@
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
-  color: color(text);
+  color: var(--text-primary);
   font-weight: 400;
-  border-bottom: 1px solid color(grey, 200);
+  border-bottom: 1px solid var(--border-subtle);
   width: 100%;
 
   &__name {

--- a/src/features/admin-auth/ui/sign-in-view/sign-in-view.module.scss
+++ b/src/features/admin-auth/ui/sign-in-view/sign-in-view.module.scss
@@ -19,7 +19,7 @@
 .title {
   font-size: 24px;
   font-weight: 600;
-  color: color(grey, 900);
+  color: var(--text-primary);
   text-align: center;
 }
 
@@ -30,7 +30,7 @@
   padding-block: 6px;
   align-items: center;
   border-radius: 20px;
-  border: 1px solid color(grey, 900);
+  border: 1px solid var(--border-strong);
 
   input {
     width: 100%;
@@ -39,22 +39,22 @@
     font-size: 20px;
     font-weight: 400;
     line-height: 40px;
-    color: color(text);
+    color: var(--text-primary);
     &::placeholder {
-      color: color(grey, 500);
+      color: var(--text-muted);
     }
   }
 }
 
 .error {
   font-size: 14px;
-  color: color(chords);
+  color: var(--chords);
   text-align: center;
 }
 
 .button {
   @include backgroundGradient;
-  color: color(white);
+  color: var(--on-accent);
   border: none;
   border-radius: 20px;
   padding: 12px 24px;

--- a/src/features/delete-song/ui/delete-song-flow.module.scss
+++ b/src/features/delete-song/ui/delete-song-flow.module.scss
@@ -24,7 +24,7 @@
   &__text {
     font-size: 18px;
     font-weight: 500;
-    color: #333;
+    color: var(--text-primary);
     margin: 0;
   }
 
@@ -42,16 +42,16 @@
 
   &__cancel {
     padding: 8px 20px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-default);
     border-radius: 8px;
     background: none;
     font-size: 15px;
     cursor: pointer;
-    color: #555;
+    color: var(--text-secondary);
     transition: background 0.15s;
 
     &:hover:not(:disabled) {
-      background: #f0f0f0;
+      background: var(--bg-surface-hover);
     }
 
     &:disabled {

--- a/src/features/filter-songs/ui/filter/filter.module.scss
+++ b/src/features/filter-songs/ui/filter/filter.module.scss
@@ -8,7 +8,7 @@
 .btn {
   display: flex;
   padding: 5px;
-  border: 1px solid color(grey, 500);
+  border: 1px solid var(--border-default);
   border-radius: 15px;
   width: fit-content;
   background: none;
@@ -16,6 +16,6 @@
   cursor: pointer;
 
   &--selected {
-    background: color(grey);
+    background: var(--bg-surface-hover);
   }
 }

--- a/src/features/search-songs/ui/search-bar/search-bar.module.scss
+++ b/src/features/search-songs/ui/search-bar/search-bar.module.scss
@@ -8,7 +8,7 @@
   align-items: center;
   gap: 20px;
   border-radius: 20px;
-  border: 1px solid color(grey, 900);
+  border: 1px solid var(--border-strong);
   &__input {
     width: calc(100% - 40px);
     outline: none;
@@ -17,9 +17,9 @@
     font-style: normal;
     font-weight: 400;
     line-height: 40px;
-    color: color(text);
+    color: var(--text-primary);
     &::placeholder {
-      color: color(grey, 500);
+      color: var(--text-muted);
     }
   }
 }

--- a/src/features/select-tonality/ui/tonality-select/tonality-select.module.scss
+++ b/src/features/select-tonality/ui/tonality-select/tonality-select.module.scss
@@ -5,12 +5,12 @@
   flex-direction: column;
   &__item {
     cursor: pointer;
-    border-bottom: 1px solid color(grey, 300);
+    border-bottom: 1px solid var(--border-subtle);
     padding: 10px 30px;
     font-size: 24px;
     &--active {
       font-weight: 600;
-      background: color(grey, 200);
+      background: var(--bg-surface-hover);
     }
   }
 }
@@ -21,9 +21,9 @@
   outline: none;
   border-radius: 50%;
   background: transparent;
-  color: color(grey, 800);
+  color: var(--text-secondary);
   padding: 8px;
-  border: 1px solid color(grey, 700);
+  border: 1px solid var(--border-strong);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   width: 47px;
   font-weight: 600;

--- a/src/features/trigger-deploy/ui/trigger-deploy-button.module.scss
+++ b/src/features/trigger-deploy/ui/trigger-deploy-button.module.scss
@@ -40,30 +40,30 @@
   &__title {
     font-size: 18px;
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     margin: 0;
   }
 
   &__warning {
     font-size: 15px;
-    color: #555;
+    color: var(--text-secondary);
     margin: 0;
   }
 
   &__info {
     font-size: 14px;
-    color: #777;
+    color: var(--text-muted);
     margin: 0;
   }
 
   &__countdown {
     font-size: 15px;
-    color: #555;
+    color: var(--text-secondary);
     margin: 0;
 
     strong {
       font-variant-numeric: tabular-nums;
-      color: #333;
+      color: var(--text-primary);
     }
   }
 
@@ -82,16 +82,16 @@
 
   &__cancel {
     padding: 8px 20px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-default);
     border-radius: 8px;
     background: none;
     font-size: 15px;
     cursor: pointer;
-    color: #555;
+    color: var(--text-secondary);
     transition: background 0.15s;
 
     &:hover {
-      background: #f0f0f0;
+      background: var(--bg-surface-hover);
     }
   }
 

--- a/src/shared/styles/global.scss
+++ b/src/shared/styles/global.scss
@@ -1,3 +1,4 @@
+@use './theme.scss';
 @use './mixins.scss' as *;
 
 * {
@@ -10,6 +11,14 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.ReactModal__Content {
+  background: var(--bg-page) !important;
+  color: var(--text-primary) !important;
+  border-color: var(--border-default) !important;
 }
 
 a {
@@ -18,7 +27,7 @@ a {
 }
 
 span.chords {
-  color: color(chords);
+  color: var(--chords);
   font-weight: 700;
 }
 

--- a/src/shared/styles/theme.scss
+++ b/src/shared/styles/theme.scss
@@ -1,0 +1,41 @@
+:root {
+  color-scheme: light dark;
+
+  --bg-page: #ffffff;
+  --bg-surface: #f1f2f3;
+  --bg-surface-hover: #e8eae9;
+
+  --border-subtle: #dadce0;
+  --border-default: #9aa0a6;
+  --border-strong: #202124;
+
+  --text-primary: #000000;
+  --text-secondary: #5f6368;
+  --text-muted: #9aa0a6;
+
+  // Text/icons that sit on top of the coloured gradient header or the
+  // solid accent background — stays light regardless of theme.
+  --on-accent: #f1f2f3;
+
+  --accent: #353535;
+  --chords: #ed7676;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-page: #121212;
+    --bg-surface: #1e1f20;
+    --bg-surface-hover: #2c2d2f;
+
+    --border-subtle: #3c4043;
+    --border-default: #5f6368;
+    --border-strong: #9aa0a6;
+
+    --text-primary: #e8eaed;
+    --text-secondary: #b0b4ba;
+    --text-muted: #8a8f98;
+
+    --accent: #4a4a4a;
+    --chords: #ff8a8a;
+  }
+}

--- a/src/widgets/admin-song-list/ui/admin-song-list.module.scss
+++ b/src/widgets/admin-song-list/ui/admin-song-list.module.scss
@@ -25,7 +25,7 @@
     font-size: 40px;
     font-weight: 500;
     line-height: 40px;
-    color: color(grey, 100);
+    color: var(--on-accent);
   }
 
   &__actions {
@@ -50,7 +50,7 @@
       border-color 0.15s;
 
     &:hover {
-      color: color(grey, 100);
+      color: var(--on-accent);
       background: rgba(255, 255, 255, 0.25);
       border-color: rgba(255, 255, 255, 0.4);
     }
@@ -75,19 +75,19 @@
   align-items: center;
   gap: 12px;
   padding: 10px 22px;
-  border-bottom: 1px solid color(grey, 200);
+  border-bottom: 1px solid var(--border-subtle);
   text-decoration: none;
   cursor: pointer;
   transition: background 0.1s;
 
   &:hover {
-    background: color(grey, 200);
+    background: var(--bg-surface-hover);
   }
 
   &__order {
     flex-shrink: 0;
     font-size: 16px;
-    color: color(grey);
+    color: var(--text-muted);
     min-width: 32px;
     text-align: right;
   }
@@ -95,7 +95,7 @@
   &__name {
     font-size: 20px;
     font-weight: 400;
-    color: color(text);
+    color: var(--text-primary);
     line-height: 27px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -113,7 +113,7 @@
   height: 56px;
   border-radius: 50%;
   @include backgroundGradient;
-  color: color(grey, 100);
+  color: var(--on-accent);
   font-size: 32px;
   display: flex;
   align-items: center;
@@ -131,7 +131,7 @@
 .loading {
   padding: 16px;
   text-align: center;
-  color: color(grey);
+  color: var(--text-muted);
   font-size: 16px;
 }
 

--- a/src/widgets/edit-song-view/ui/edit-song-view.module.scss
+++ b/src/widgets/edit-song-view/ui/edit-song-view.module.scss
@@ -22,7 +22,7 @@
     justify-content: center;
     background: rgba(255, 255, 255, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.4);
-    color: color(grey, 100);
+    color: var(--on-accent);
     text-decoration: none;
     width: 36px;
     height: 36px;
@@ -42,7 +42,7 @@
   &__title {
     font-size: 28px;
     font-weight: 500;
-    color: color(grey, 100);
+    color: var(--on-accent);
   }
 
   &__save {
@@ -51,7 +51,7 @@
     justify-content: center;
     background: rgba(255, 255, 255, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.4);
-    color: color(grey, 100);
+    color: var(--on-accent);
     width: 36px;
     height: 36px;
     border-radius: 8px;
@@ -88,7 +88,7 @@
 .loading {
   padding: 40px;
   text-align: center;
-  color: color(grey);
+  color: var(--text-muted);
   font-size: 16px;
 }
 
@@ -107,10 +107,10 @@
     flex: 1;
     padding: 8px;
     background: none;
-    border: 1px solid color(grey, 300);
+    border: 1px solid var(--border-subtle);
     font-size: 14px;
     cursor: pointer;
-    color: color(grey);
+    color: var(--text-muted);
     transition:
       background 0.15s,
       color 0.15s;
@@ -124,9 +124,9 @@
     }
 
     &--active {
-      background: color(main);
-      color: color(grey, 100);
-      border-color: color(main);
+      background: var(--accent);
+      color: var(--on-accent);
+      border-color: var(--accent);
     }
   }
 }
@@ -176,7 +176,7 @@
   &__label {
     font-size: 13px;
     font-weight: 600;
-    color: color(grey);
+    color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -193,40 +193,40 @@
     background: none;
     border: none;
     cursor: pointer;
-    color: color(grey);
+    color: var(--text-muted);
     padding: 2px;
     border-radius: 4px;
     transition: color 0.15s;
 
     &:hover {
-      color: color(main);
+      color: var(--accent);
     }
   }
 
   &__input,
   &__select {
     padding: 8px 12px;
-    border: 1px solid color(grey, 300);
+    border: 1px solid var(--border-subtle);
     border-radius: 8px;
     font-size: 16px;
-    color: color(text);
-    background: color(grey, 100);
+    color: var(--text-primary);
+    background: var(--bg-surface);
     transition: border-color 0.15s;
 
     &:focus {
       outline: none;
-      border-color: color(main);
+      border-color: var(--accent);
     }
   }
 
   &__textarea {
     padding: 10px 12px;
-    border: 1px solid color(grey, 300);
+    border: 1px solid var(--border-subtle);
     border-radius: 8px;
     font-size: 14px;
     font-family: monospace;
-    color: color(text);
-    background: color(grey, 100);
+    color: var(--text-primary);
+    background: var(--bg-surface);
     resize: none;
     flex: 1;
     min-height: 200px;
@@ -239,7 +239,7 @@
 
     &:focus {
       outline: none;
-      border-color: color(main);
+      border-color: var(--accent);
     }
   }
 
@@ -259,10 +259,10 @@
 .preview {
   flex: 1;
   min-width: 0;
-  background: color(grey, 100);
+  background: var(--bg-surface);
   border-radius: 12px;
   padding: 24px 4px;
-  border: 1px solid color(grey, 200);
+  border: 1px solid var(--border-subtle);
 
   &--hidden {
     display: none;
@@ -275,7 +275,7 @@
   &__empty {
     padding: 40px;
     text-align: center;
-    color: color(grey, 300);
+    color: var(--text-muted);
     font-size: 14px;
   }
 }
@@ -295,7 +295,7 @@
   &__text {
     font-size: 18px;
     font-weight: 500;
-    color: color(text);
+    color: var(--text-primary);
     margin: 0;
   }
 
@@ -307,16 +307,16 @@
 
   &__cancel {
     padding: 8px 20px;
-    border: 1px solid color(grey, 300);
+    border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background: none;
     font-size: 15px;
     cursor: pointer;
-    color: color(grey);
+    color: var(--text-muted);
     transition: background 0.15s;
 
     &:hover:not(:disabled) {
-      background: color(grey, 200);
+      background: var(--bg-surface-hover);
     }
 
     &:disabled {
@@ -329,10 +329,10 @@
     padding: 8px 20px;
     border: none;
     border-radius: 8px;
-    background: color(main);
+    background: var(--accent);
     font-size: 15px;
     cursor: pointer;
-    color: color(grey, 100);
+    color: var(--on-accent);
     transition: opacity 0.15s;
 
     &:hover:not(:disabled) {
@@ -355,7 +355,7 @@
   &__title {
     font-size: 18px;
     font-weight: 600;
-    color: color(text);
+    color: var(--text-primary);
     margin: 0;
   }
 
@@ -366,11 +366,11 @@
     flex-direction: column;
     gap: 10px;
     font-size: 15px;
-    color: color(text);
+    color: var(--text-primary);
     line-height: 1.6;
 
     code {
-      background: color(grey, 200);
+      background: var(--bg-surface-hover);
       padding: 1px 5px;
       border-radius: 4px;
       font-family: monospace;
@@ -381,16 +381,16 @@
   &__close {
     align-self: flex-end;
     padding: 8px 20px;
-    border: 1px solid color(grey, 300);
+    border: 1px solid var(--border-subtle);
     border-radius: 8px;
     background: none;
     font-size: 15px;
     cursor: pointer;
-    color: color(grey);
+    color: var(--text-muted);
     transition: background 0.15s;
 
     &:hover {
-      background: color(grey, 200);
+      background: var(--bg-surface-hover);
     }
   }
 }

--- a/src/widgets/song-list/ui/song-list.module.scss
+++ b/src/widgets/song-list/ui/song-list.module.scss
@@ -3,7 +3,7 @@
 .header {
   width: 100%;
 
-  background: color(main);
+  background: var(--accent);
   display: flex;
   padding: 20px 57px;
   justify-content: center;
@@ -15,7 +15,7 @@
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   @include backgroundGradient;
   &__title {
-    color: color(grey, 100);
+    color: var(--on-accent);
     font-size: 40px;
     font-style: normal;
     font-weight: 500;
@@ -54,7 +54,7 @@
   outline: none;
   width: fit-content;
   margin-inline: auto;
-  border: 1px solid color(grey);
+  border: 1px solid var(--border-default);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   cursor: pointer;
   & > {

--- a/src/widgets/song-view/ui/song-view.module.scss
+++ b/src/widgets/song-view/ui/song-view.module.scss
@@ -11,7 +11,7 @@
   position: relative;
   padding-top: 20px;
   &__title {
-    color: color(text);
+    color: var(--text-primary);
     font-size: 30px;
     font-style: normal;
     font-weight: 600;
@@ -28,7 +28,7 @@
   gap: 10px;
 
   &__title {
-    color: color(text);
+    color: var(--text-primary);
     font-size: 24px;
     font-style: normal;
     font-weight: 600;
@@ -36,7 +36,7 @@
   }
   &__text {
     display: grid;
-    color: color(text);
+    color: var(--text-primary);
     font-size: 20px;
     font-style: normal;
     font-weight: 400;
@@ -47,14 +47,14 @@
 
 .text {
   display: grid;
-  color: color(text);
+  color: var(--text-primary);
   font-size: 20px;
   font-style: normal;
   font-weight: 400;
   line-height: 27px;
   white-space: pre-wrap;
   &__chords {
-    color: color(chords);
+    color: var(--chords);
     font-weight: 700;
 
     &--hide {
@@ -76,9 +76,9 @@
     outline: none;
     border-radius: 50%;
     background: transparent;
-    color: color(grey, 800);
+    color: var(--text-secondary);
     padding: 8px;
-    border: 1px solid color(grey, 700);
+    border: 1px solid var(--border-strong);
     box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
     & > svg {
       height: 30px;


### PR DESCRIPTION
Introduce semantic CSS custom properties (background, surface, text,
border, accent, chords) defined in src/shared/styles/theme.scss, with
dark values applied automatically via prefers-color-scheme so the app
matches the user's browser/OS setting without a manual toggle. Migrate
every component's hardcoded palette colors to these tokens, theme the
react-modal dialogs, and add a themeColor viewport meta for the browser
chrome.